### PR TITLE
support barnacles & add Functional Medal mod cookpot support

### DIFF
--- a/modmain.lua
+++ b/modmain.lua
@@ -136,7 +136,7 @@ local function ContainerPostConstruct(inst, prefab)
 
 
   -- only apply craftpot modification to the following list of prefabs
-  if not tableContains(inst.inst.prefab, {'cookpot', 'portablecookpot', 'deluxpot'}) then
+  if not tableContains(inst.inst.prefab, {'cookpot', 'portablecookpot', 'deluxpot', 'medal_cookpot'}) then
     return false
   end
 

--- a/scripts/components/knownfoods.lua
+++ b/scripts/components/knownfoods.lua
@@ -7,7 +7,7 @@ local function IsClientSim()
 end
 
 local KnownFoods = Class(function(self)
-  self._dtag = 0.5
+  self._dtag = 0.25
   self._basicCooker = 'cookpot'
   self._cooker = {} -- opened cooker inst
   self._cookerName = self._basicCooker

--- a/scripts/components/knownfoods.lua
+++ b/scripts/components/knownfoods.lua
@@ -278,7 +278,7 @@ function KnownFoods:_SmartSearch(test)
     else -- test returned false or compare error (-1 or 0)
       local access = table.remove(access_list)
       if access.type == 'tags' then
-        tags[access.field] = tags[access.field] and tags[access.field] + 0.5 or 0.5
+        tags[access.field] = tags[access.field] and tags[access.field] + 0.25 or 0.25
         if tags[access.field] > 4 then -- quit condition, tag over max value
           print ("Could not find recipe, tag over max")
           return false


### PR DESCRIPTION
barnacles have 0.25 heat, but Bacon and Eggs requires 1.5 meat in mod (in fact it just need meat > 1).

so a meat, a barnacles, two eggs can make Bacon and Eggs, even it have only 1.25 meat value.

so I updated the "delta" value to make it works fine.

![2022-05-02 00-08-19屏幕截图](https://user-images.githubusercontent.com/38349409/166154410-fc101786-ed5f-465e-801f-a6ddd1c64b58.png)

and [Functional Medal](https://steamcommunity.com/sharedfiles/filedetails/?id=1909182187) mod add a new pot with a new prefab name, so i add it to cookpot check list.