### PR TITLE
Merge pull#3 and pull#7 together, and fix portable cookpot

### DIFF
--- a/modmain.lua
+++ b/modmain.lua
@@ -45,6 +45,7 @@ local STRINGS = GLOBAL.STRINGS
 -- Modder API provided in the following modules
 require "ingredienttags"
 require "cookingpots"
+require "foodatlas"
 
 -- declared within cookingpots, so must be located after require
 local COOKINGPOTS = GLOBAL.COOKINGPOTS

--- a/scripts/components/knownfoods.lua
+++ b/scripts/components/knownfoods.lua
@@ -27,7 +27,7 @@ local KnownFoods = Class(function(self)
   }
 
   if IsClientSim() then
-    self._filepath = "session/"..(TheNet:GetSessionIdentifier() or "INVALID_SESSION").."/"..(TheNet:GetUserID() or "INVALID_USERID").."_/knownfoods_data"
+    self._name = "craftpot_"..(TheNet:GetSessionIdentifier() or "INVALID_SESSION").."_"..(TheNet:GetUserID() or "INVALID_USERID").."_knownfoods_data"
     self:OnLoad()
   end
 end)
@@ -42,7 +42,7 @@ function KnownFoods:OnSave()
   end
   if IsClientSim() then
     local str = json.encode(data)
-    TheSim:SetPersistentString(self._filepath, str, true)
+    TheSim:SetPersistentString(self._name, str, true)
   else
     return data
   end
@@ -51,7 +51,7 @@ end
 function KnownFoods:OnLoad(data)
   if IsClientSim() then
     -- ClientSim load uses PersistentString data
-    TheSim:GetPersistentString(self._filepath, function(success, strdata)
+    TheSim:GetPersistentString(self._name, function(success, strdata)
       if success then
         data = json.decode(strdata)
       end

--- a/scripts/foodatlas.lua
+++ b/scripts/foodatlas.lua
@@ -5,7 +5,7 @@ function RegisterFoodAtlas(prefab, imagename, atlasname)
   if prefab ~= nil and atlasname ~= nil and imagename ~= nil then
     if FoodAtlasLookup[prefab] ~= nil then
       print("RegisterFoodAtlas: Image '" .. imagename .. "' is already registered to atlas '"
-              .. FoodAtlasLookup[imagename] .. "'")
+              .. FoodAtlasLookup[prefab][2] .. "'")
       return
     end
     FoodAtlasLookup[prefab] = {imagename, atlasname}

--- a/scripts/foodatlas.lua
+++ b/scripts/foodatlas.lua
@@ -1,0 +1,18 @@
+global("RegisterFoodAtlas")
+global("GetFoodAtlas")
+local FoodAtlasLookup = {}
+function RegisterFoodAtlas(prefab, imagename, atlasname)
+  if prefab ~= nil and atlasname ~= nil and imagename ~= nil then
+    if FoodAtlasLookup[prefab] ~= nil then
+      print("RegisterFoodAtlas: Image '" .. imagename .. "' is already registered to atlas '"
+              .. FoodAtlasLookup[imagename] .. "'")
+      return
+    end
+    FoodAtlasLookup[prefab] = {imagename, atlasname}
+  end
+end
+function GetFoodAtlas(prefab)
+  local lookup = FoodAtlasLookup[prefab]
+  if lookup then return unpack(lookup) end
+  return nil, nil
+end

--- a/scripts/utils/resolveinventoryitemassets.lua
+++ b/scripts/utils/resolveinventoryitemassets.lua
@@ -7,10 +7,6 @@ return function(prefab)
   local atlas = GetInventoryItemAtlas(item_tex)
   local localized_name = STRINGS.NAMES[string.upper(prefab)] or prefab
   local prefabData = Prefabs[prefab]
-  
-  local registered_image, registered_altas = GetFoodAtlas(prefab)
-  item_tex = registered_image or item_tex
-  atlas = registered_altas or atlas
 
   if prefabData then
     -- first run we find assets with exact match of prefab name
@@ -35,6 +31,11 @@ return function(prefab)
       end
     end
   end
+
+  -- manually added via mod api
+  local registered_image, registered_altas = GetFoodAtlas(prefab)
+  item_tex = registered_image or item_tex
+  atlas = registered_altas or atlas
 
   return SanitizeAssets(item_tex, atlas, localized_name)
 end

--- a/scripts/utils/resolveinventoryitemassets.lua
+++ b/scripts/utils/resolveinventoryitemassets.lua
@@ -7,6 +7,10 @@ return function(prefab)
   local atlas = GetInventoryItemAtlas(item_tex)
   local localized_name = STRINGS.NAMES[string.upper(prefab)] or prefab
   local prefabData = Prefabs[prefab]
+  
+  local registered_image, registered_altas = GetFoodAtlas(prefab)
+  item_tex = registered_image or item_tex
+  atlas = registered_altas or atlas
 
   if prefabData then
     -- first run we find assets with exact match of prefab name

--- a/scripts/widgets/foodcrafting.lua
+++ b/scripts/widgets/foodcrafting.lua
@@ -356,8 +356,7 @@ function FoodCrafting:_UpdateFoodStats(ingdata, num_ing, inv_ings)
 	for idx, fooditem in ipairs(self.allfoods) do
 		local recipe = fooditem.recipe
 		self.knownfoods:UpdateRecipe(recipe, ingdata)
-
-		recipe.correctCooker = recipe.supportedCookers[self._cookerName]
+    recipe.correctCooker = recipe.supportedCookers[self._cookerName] or recipe.supportedCookers['cookpot']
 		if num_ing == 4 and recipe.correctCooker and recipe.reqsmatch then
 			recipe.readytocook = true
 			if recipe.priority > cook_priority then

--- a/scripts/widgets/fooditem.lua
+++ b/scripts/widgets/fooditem.lua
@@ -28,7 +28,14 @@ local FoodItem = Class(Widget, function(self, owner, foodcrafting, recipe, hasPo
 end)
 
 function FoodItem:DefineAssetData()
-  self.item_tex, self.atlas, self.localized_name = ResolveInventoryItemAssets(self.prefab)
+  self.item_tex = self.prefab..'.tex'
+  self.atlas = GetInventoryItemAtlas(self.item_tex)
+  self.localized_name = STRINGS.NAMES[string.upper(self.prefab)] or self.prefab
+  -- No idea about this issue: 
+  --    https://forums.kleientertainment.com/forums/topic/145440-the-atlas-resolved-by-getinventoryitematlas-cannot-be-tested-by-thesimatlascontains
+  -- if not self.atlas or not TheSim:AtlasContains(self.atlas, self.item_tex) then
+  --   print("Craft pot ~ AssetData: failed to resolve[" .. self.prefab .. "]" .. self.localized_name .. " tex:" .. (self.item_tex or "nil") .. " atlas:" .. (self.atlas or "nil"))
+  -- end
 end
 
 function FoodItem:SetSlot(slot)

--- a/scripts/widgets/fooditem.lua
+++ b/scripts/widgets/fooditem.lua
@@ -28,14 +28,7 @@ local FoodItem = Class(Widget, function(self, owner, foodcrafting, recipe, hasPo
 end)
 
 function FoodItem:DefineAssetData()
-  self.item_tex = self.prefab..'.tex'
-  self.atlas = GetInventoryItemAtlas(self.item_tex)
-  self.localized_name = STRINGS.NAMES[string.upper(self.prefab)] or self.prefab
-  -- No idea about this issue: 
-  --    https://forums.kleientertainment.com/forums/topic/145440-the-atlas-resolved-by-getinventoryitematlas-cannot-be-tested-by-thesimatlascontains
-  -- if not self.atlas or not TheSim:AtlasContains(self.atlas, self.item_tex) then
-  --   print("Craft pot ~ AssetData: failed to resolve[" .. self.prefab .. "]" .. self.localized_name .. " tex:" .. (self.item_tex or "nil") .. " atlas:" .. (self.atlas or "nil"))
-  -- end
+  self.item_tex, self.atlas, self.localized_name = ResolveInventoryItemAssets(self.prefab)
 end
 
 function FoodItem:SetSlot(slot)


### PR DESCRIPTION
- Fix knownfoods session storage (aka save cooked recipes) (by seanxlliu)
- Add new mode API to provide inventory images used in original recipes for custom prefabs (by ZzzzzzzSkyward)
- Fix DS Hamlet issue with portable cookpot displaying default cookpot recipes as permanently locked

Closes [pull#3](https://github.com/IMalyugin/dont-starve-mod-craftpot/pull/3) [pull#7](https://github.com/IMalyugin/dont-starve-mod-craftpot/pull/7) https://github.com/IMalyugin/dont-starve-mod-craftpot/issues/4