### PR TITLE
add resolvefilepath

### DIFF
--- a/scripts/utils/checkinventoryitematlas.lua
+++ b/scripts/utils/checkinventoryitematlas.lua
@@ -1,0 +1,8 @@
+local resolvefilepath_soft = rawget(_G,"resolvefilepath_soft") or softresolvefilepath
+return function(atlas, tex)
+  if atlas and tex then
+    local absolute_path = resolvefilepath_soft(atlas)
+    if absolute_path and TheSim:AtlasContains(absolute_path, tex) then return absolute_path end
+  end
+  return nil
+end

--- a/scripts/utils/checkinventoryitematlas.lua
+++ b/scripts/utils/checkinventoryitematlas.lua
@@ -1,8 +1,0 @@
-local resolvefilepath_soft = rawget(_G,"resolvefilepath_soft") or softresolvefilepath
-return function(atlas, tex)
-  if atlas and tex then
-    local absolute_path = resolvefilepath_soft(atlas)
-    if absolute_path and TheSim:AtlasContains(absolute_path, tex) then return absolute_path end
-  end
-  return nil
-end

--- a/scripts/utils/resolveinventoryitemassets.lua
+++ b/scripts/utils/resolveinventoryitemassets.lua
@@ -1,5 +1,6 @@
 local GetInventoryItemAtlas = require "utils/getinventoryitematlas"
-local CheckAtlas = require "utils/checkinventoryitematlas"
+local SanitizeAssets = require "utils/sanitizeassets"
+
 -- An ugly, yet partially efficient attempt at getting inventory item assets
 
 local QUAGMIRE_PORTS =
@@ -11,47 +12,11 @@ local QUAGMIRE_PORTS =
 }
 local inventoryItemAtlasLookup = {} -- Cache the results
 return function(prefab)
-<<<<<<< Updated upstream
-  local item_tex = prefab .. '.tex'
-=======
   local item_tex = QUAGMIRE_PORTS[prefab] and "quagmire_"..prefab..'.tex' or prefab..'.tex'
->>>>>>> Stashed changes
   local atlas = GetInventoryItemAtlas(item_tex)
   local localized_name = STRINGS.NAMES[string.upper(prefab)] or prefab
   local prefabData = Prefabs[prefab]
 
-<<<<<<< Updated upstream
-  -- If registered
-  atlas = CheckAtlas(atlas, item_tex)
-  if atlas then return item_tex, atlas, localized_name end
-
-  -- find in images/inventoryimages/prefab.xml
-  atlas = CheckAtlas("images/inventoryimages/" .. prefab .. '.xml', item_tex)
-  if atlas then return item_tex, atlas, localized_name end
-
-  -- find in prefabData
-  if prefabData then
-    -- first run we find assets with exact match of prefab name
-    for _, asset in ipairs(prefabData.assets) do
-      if asset.type == "INV_IMAGE" then
-        item_tex = asset.file .. '.tex'
-        atlas = GetInventoryItemAtlas(item_tex)
-        if atlas then break end
-      elseif asset.type == "ATLAS" then
-        atlas = asset.file
-        break
-      end
-    end
-    atlas = CheckAtlas(atlas, item_tex)
-    if atlas then return item_tex, atlas, localized_name end
-
-    -- second run, a special case for migrated items, they are prefixed via `quagmire_`
-    for _, asset in ipairs(Prefabs[prefab].assets) do
-      if asset.type == "INV_IMAGE" then
-        item_tex = 'quagmire_' .. asset.file .. '.tex'
-        atlas = GetInventoryItemAtlas(item_tex)
-        if atlas then break end
-=======
   if inventoryItemAtlasLookup[prefab] then -- Use cached result if available
     return item_tex,inventoryItemAtlasLookup[prefab],localized_name
   end
@@ -70,11 +35,8 @@ return function(prefab)
           inventoryItemAtlasLookup[prefab] = asset.file
           return item_tex,asset.file,localized_name
         end
->>>>>>> Stashed changes
       end
     end
-    atlas = CheckAtlas(atlas, item_tex)
-    if atlas then return item_tex, atlas, localized_name end
   end
 
   --Maybe we can use this to find mod food atlas
@@ -94,17 +56,11 @@ return function(prefab)
   -- manually added via mod api
   local registered_image, registered_altas = GetFoodAtlas(prefab)
   item_tex = registered_image or item_tex
-  atlas = CheckAtlas(registered_altas, item_tex)
-  if atlas then return item_tex, atlas, localized_name end
+  atlas = registered_altas or atlas
 
-<<<<<<< Updated upstream
-  return nil, nil, localized_name
-end
-=======
   if atlas and TheSim:AtlasContains(resolvefilepath(atlas), item_tex) then
     inventoryItemAtlasLookup[prefab] = atlas
     return item_tex, atlas, localized_name
   end
   return nil, nil, localized_name
 end
->>>>>>> Stashed changes

--- a/scripts/utils/resolveinventoryitemassets.lua
+++ b/scripts/utils/resolveinventoryitemassets.lua
@@ -1,12 +1,26 @@
 local GetInventoryItemAtlas = require "utils/getinventoryitematlas"
 local CheckAtlas = require "utils/checkinventoryitematlas"
 -- An ugly, yet partially efficient attempt at getting inventory item assets
+
+local QUAGMIRE_PORTS =
+{
+    tomato = true,
+    tomato_cooked = true,
+    onion = true,
+    onion_cooked = true,
+}
+local inventoryItemAtlasLookup = {} -- Cache the results
 return function(prefab)
+<<<<<<< Updated upstream
   local item_tex = prefab .. '.tex'
+=======
+  local item_tex = QUAGMIRE_PORTS[prefab] and "quagmire_"..prefab..'.tex' or prefab..'.tex'
+>>>>>>> Stashed changes
   local atlas = GetInventoryItemAtlas(item_tex)
   local localized_name = STRINGS.NAMES[string.upper(prefab)] or prefab
   local prefabData = Prefabs[prefab]
 
+<<<<<<< Updated upstream
   -- If registered
   atlas = CheckAtlas(atlas, item_tex)
   if atlas then return item_tex, atlas, localized_name end
@@ -37,10 +51,44 @@ return function(prefab)
         item_tex = 'quagmire_' .. asset.file .. '.tex'
         atlas = GetInventoryItemAtlas(item_tex)
         if atlas then break end
+=======
+  if inventoryItemAtlasLookup[prefab] then -- Use cached result if available
+    return item_tex,inventoryItemAtlasLookup[prefab],localized_name
+  end
+
+  --Original and Mod with registered 
+  if atlas and TheSim:AtlasContains(resolvefilepath(atlas), item_tex) then
+    inventoryItemAtlasLookup[prefab] = atlas
+    return item_tex,atlas,localized_name
+  end 
+
+  --prefabData.assets
+  if prefabData then
+    for _, asset in ipairs(prefabData.assets) do
+      if asset.type == "ATLAS" and asset.file then
+        if TheSim:AtlasContains(resolvefilepath(asset.file), item_tex) then
+          inventoryItemAtlasLookup[prefab] = asset.file
+          return item_tex,asset.file,localized_name
+        end
+>>>>>>> Stashed changes
       end
     end
     atlas = CheckAtlas(atlas, item_tex)
     if atlas then return item_tex, atlas, localized_name end
+  end
+
+  --Maybe we can use this to find mod food atlas
+  local mod_atlas = "images/inventoryimages/"..prefab..'.xml'
+  if softresolvefilepath(mod_atlas) and TheSim:AtlasContains(resolvefilepath(mod_atlas), item_tex) then
+    inventoryItemAtlasLookup[prefab] = mod_atlas
+    return item_tex,mod_atlas,localized_name
+  end
+
+  --Maybe we can use this to find mod food atlas
+  mod_atlas = "images/"..prefab..'.xml'
+  if softresolvefilepath(mod_atlas) and TheSim:AtlasContains(resolvefilepath(mod_atlas), item_tex) then
+    inventoryItemAtlasLookup[prefab] = mod_atlas
+    return item_tex,mod_atlas,localized_name
   end
 
   -- manually added via mod api
@@ -49,5 +97,14 @@ return function(prefab)
   atlas = CheckAtlas(registered_altas, item_tex)
   if atlas then return item_tex, atlas, localized_name end
 
+<<<<<<< Updated upstream
   return nil, nil, localized_name
 end
+=======
+  if atlas and TheSim:AtlasContains(resolvefilepath(atlas), item_tex) then
+    inventoryItemAtlasLookup[prefab] = atlas
+    return item_tex, atlas, localized_name
+  end
+  return nil, nil, localized_name
+end
+>>>>>>> Stashed changes

--- a/scripts/utils/resolveinventoryitemassets.lua
+++ b/scripts/utils/resolveinventoryitemassets.lua
@@ -1,41 +1,53 @@
 local GetInventoryItemAtlas = require "utils/getinventoryitematlas"
-local SanitizeAssets = require "utils/sanitizeassets"
-local resolvefilepath_soft = rawget(_G,"resolvefilepath_soft") or softresolvefilepath
+local CheckAtlas = require "utils/checkinventoryitematlas"
 -- An ugly, yet partially efficient attempt at getting inventory item assets
 return function(prefab)
-  local item_tex = prefab..'.tex'
+  local item_tex = prefab .. '.tex'
   local atlas = GetInventoryItemAtlas(item_tex)
   local localized_name = STRINGS.NAMES[string.upper(prefab)] or prefab
   local prefabData = Prefabs[prefab]
 
+  -- If registered
+  atlas = CheckAtlas(atlas, item_tex)
+  if atlas then return item_tex, atlas, localized_name end
+
+  -- find in images/inventoryimages/prefab.xml
+  atlas = CheckAtlas("images/inventoryimages/" .. prefab .. '.xml', item_tex)
+  if atlas then return item_tex, atlas, localized_name end
+
+  -- find in prefabData
   if prefabData then
     -- first run we find assets with exact match of prefab name
-    if not atlas or not TheSim:AtlasContains(resolvefilepath_soft(atlas), item_tex) then
-      for _, asset in ipairs(prefabData.assets) do
-        if asset.type == "INV_IMAGE" then
-          item_tex = asset.file..'.tex'
-          atlas = GetInventoryItemAtlas(item_tex)
-        elseif asset.type == "ATLAS" then
-          atlas = asset.file
-        end
+    for _, asset in ipairs(prefabData.assets) do
+      if asset.type == "INV_IMAGE" then
+        item_tex = asset.file .. '.tex'
+        atlas = GetInventoryItemAtlas(item_tex)
+        if atlas then break end
+      elseif asset.type == "ATLAS" then
+        atlas = asset.file
+        break
       end
     end
+    atlas = CheckAtlas(atlas, item_tex)
+    if atlas then return item_tex, atlas, localized_name end
 
     -- second run, a special case for migrated items, they are prefixed via `quagmire_`
-    if not atlas or not TheSim:AtlasContains(resolvefilepath_soft(atlas), item_tex) then
-      for _, asset in ipairs(Prefabs[prefab].assets) do
-        if asset.type == "INV_IMAGE" then
-          item_tex = 'quagmire_'..asset.file..'.tex'
-          atlas = GetInventoryItemAtlas(item_tex)
-        end
+    for _, asset in ipairs(Prefabs[prefab].assets) do
+      if asset.type == "INV_IMAGE" then
+        item_tex = 'quagmire_' .. asset.file .. '.tex'
+        atlas = GetInventoryItemAtlas(item_tex)
+        if atlas then break end
       end
     end
+    atlas = CheckAtlas(atlas, item_tex)
+    if atlas then return item_tex, atlas, localized_name end
   end
 
   -- manually added via mod api
   local registered_image, registered_altas = GetFoodAtlas(prefab)
   item_tex = registered_image or item_tex
-  atlas = registered_altas or atlas
+  atlas = CheckAtlas(registered_altas, item_tex)
+  if atlas then return item_tex, atlas, localized_name end
 
-  return SanitizeAssets(item_tex, atlas, localized_name)
+  return nil, nil, localized_name
 end

--- a/scripts/utils/resolveinventoryitemassets.lua
+++ b/scripts/utils/resolveinventoryitemassets.lua
@@ -1,6 +1,6 @@
 local GetInventoryItemAtlas = require "utils/getinventoryitematlas"
 local SanitizeAssets = require "utils/sanitizeassets"
-
+local resolvefilepath_soft = rawget(_G,"resolvefilepath_soft") or softresolvefilepath
 -- An ugly, yet partially efficient attempt at getting inventory item assets
 return function(prefab)
   local item_tex = prefab..'.tex'
@@ -10,7 +10,7 @@ return function(prefab)
 
   if prefabData then
     -- first run we find assets with exact match of prefab name
-    if not atlas or not TheSim:AtlasContains(atlas, item_tex) then
+    if not atlas or not TheSim:AtlasContains(resolvefilepath_soft(atlas), item_tex) then
       for _, asset in ipairs(prefabData.assets) do
         if asset.type == "INV_IMAGE" then
           item_tex = asset.file..'.tex'
@@ -22,7 +22,7 @@ return function(prefab)
     end
 
     -- second run, a special case for migrated items, they are prefixed via `quagmire_`
-    if not atlas or not TheSim:AtlasContains(atlas, item_tex) then
+    if not atlas or not TheSim:AtlasContains(resolvefilepath_soft(atlas), item_tex) then
       for _, asset in ipairs(Prefabs[prefab].assets) do
         if asset.type == "INV_IMAGE" then
           item_tex = 'quagmire_'..asset.file..'.tex'

--- a/scripts/utils/sanitizeassets.lua
+++ b/scripts/utils/sanitizeassets.lua
@@ -1,6 +1,6 @@
 -- clean up to prevent assertion failure
 return function(item_tex, atlas, localized_name)
-  if atlas and TheSim:AtlasContains(atlas, item_tex) then
+  if atlas and TheSim:AtlasContains(resolvefilepath(atlas), item_tex) then
     return item_tex, resolvefilepath(atlas), localized_name
   else
     return nil, nil, localized_name

--- a/scripts/utils/sanitizeassets.lua
+++ b/scripts/utils/sanitizeassets.lua
@@ -1,6 +1,7 @@
 -- clean up to prevent assertion failure
+local resolvefilepath_soft = rawget(_G,"resolvefilepath_soft") or softresolvefilepath
 return function(item_tex, atlas, localized_name)
-  if atlas and TheSim:AtlasContains(atlas, item_tex) then
+  if atlas and TheSim:AtlasContains(resolvefilepath_soft(atlas), item_tex) then
     return item_tex, resolvefilepath(atlas), localized_name
   else
     return nil, nil, localized_name

--- a/scripts/utils/sanitizeassets.lua
+++ b/scripts/utils/sanitizeassets.lua
@@ -1,8 +1,8 @@
 -- clean up to prevent assertion failure
 local resolvefilepath_soft = rawget(_G,"resolvefilepath_soft") or softresolvefilepath
 return function(item_tex, atlas, localized_name)
-  if atlas and TheSim:AtlasContains(resolvefilepath_soft(atlas), item_tex) then
-    return item_tex, resolvefilepath(atlas), localized_name
+  if atlas and resolvefilepath_soft(atlas) and TheSim:AtlasContains(resolvefilepath_soft(atlas), item_tex) then
+    return item_tex, resolvefilepath_soft(atlas), localized_name
   else
     return nil, nil, localized_name
   end

--- a/scripts/utils/sanitizeassets.lua
+++ b/scripts/utils/sanitizeassets.lua
@@ -1,8 +1,7 @@
 -- clean up to prevent assertion failure
-local resolvefilepath_soft = rawget(_G,"resolvefilepath_soft") or softresolvefilepath
 return function(item_tex, atlas, localized_name)
-  if atlas and resolvefilepath_soft(atlas) and TheSim:AtlasContains(resolvefilepath_soft(atlas), item_tex) then
-    return item_tex, resolvefilepath_soft(atlas), localized_name
+  if atlas and TheSim:AtlasContains(atlas, item_tex) then
+    return item_tex, resolvefilepath(atlas), localized_name
   else
     return nil, nil, localized_name
   end


### PR DESCRIPTION
TheSim:AtlasContains needs the atlas path to be absolute, but many mods don't register absolute path.
See the latest commit.
Add:
Add `resolvefilepath` in `sanitizeassets.lua`
Add `resolvefilepath` in `resolveinventoryitemassets.lua`
Change:
Rewrite the `resolveinventoryitemassets` function.
1. Use a cache to avoid unnecessary query.
2. Use a built-in table of quagmire assets, since Klei will not likely to change them.
3. Try to find atlas from "images/inventoryimages/"..prefab..'.xml' and "images/"..prefab..'.xml', in case some mods don't add atlas or image in the prefab file, but in modmain.lua instead.

This will fix a special case when a mod meets the following condition:
1. Did not add ATLAS or INV_IMAGE in the prefab file. Instead, it adds assets in modmain
2. Did not RegisterInventoryItemAtlas, or registered a relative path.